### PR TITLE
[t1][3/n] join - host cannot see join button they host

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,7 @@ class EventsController < ApplicationController
       # will render app/views/events/show.<extension> by default
       @join_text = @event.people.include?(u) ? :Unjoin : :Join
       @join_btn_style = get_join_button_style(session[:username])
+      @is_viewer_host = @event.host == u
     end
   
     def index

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -38,5 +38,7 @@
   <%= link_to 'Delete', event_path(@event), 'data-method' => 'delete', 'data-confirm' => 'Are you sure?', :class => 'btn btn-danger col-2' %>
   <%= link_to 'Back to event list', events_path, :class => 'btn btn-primary col-2' %>
   <%# Below handles join/unjoin %>
+  <% if (@is_viewer_host) %>
   <%= link_to @join_text, join_path({:id=>@event.id}), :class => @join_btn_style %>
+  <% end %>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,11 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-events = [{:title => 'Go To Gym today afternoon', :host => 'Alicent Hightower', :rating => '4.9/5.0', :joined =>'0', :people => [], :status => 0, :description => 'Working out is important', :event_time => '02-Nov-2022', :attendee_limit => 2},
-    	  {:title => 'Enjoy Lunch at Junzi', :host => 'Daemon Targaryen', :rating => '4.9/5.0', :joined =>'1', :people => ['Mysaria'], :status => 0, :description => 'Let\'s eat together', :event_time => '30-Oct-2022', :attendee_limit => 4},
-    	  {:title => 'Lunch at Max Cafe', :host => 'Mysaria', :rating => '4.8/5.0', :joined =>'3', :people => ['Alicent Hightower', 'Daemon Targaryen', 'Aemon Targaryen'], :status => 1, :description => 'Sandwich and coffee!', :event_time => '05-Nov-2022', :attendee_limit => 5},
+events = [
+	{:title => 'Go To Gym today afternoon', :host => 'Alicent Hightower', :rating => '4.9/5.0', :joined =>'0', :people => [], :status => 0, :description => 'Working out is important', :event_time => '02-Nov-2022', :attendee_limit => 2},
+    {:title => 'Enjoy Lunch at Junzi', :host => 'Daemon Targaryen', :rating => '4.9/5.0', :joined =>'1', :people => ['Mysaria'], :status => 0, :description => 'Let\'s eat together', :event_time => '30-Oct-2022', :attendee_limit => 4},
+    {:title => 'Lunch at Max Cafe', :host => 'Mysaria', :rating => '4.8/5.0', :joined =>'3', :people => ['Alicent Hightower', 'Daemon Targaryen', 'Aemon Targaryen'], :status => 1, :description => 'Sandwich and coffee!', :event_time => '05-Nov-2022', :attendee_limit => 5},
+	{:title => 'WTF', :host => 'testuser', :rating => '4.8/5.0', :joined =>'10', :people => ['Alicent Hightower', 'Daemon Targaryen', 'Aemon Targaryen'], :status => 1, :description => 'WTF IS THIS!', :event_time => '05-Nov-2022', :attendee_limit => 20},
   	 ]
 
 events.each do |event|


### PR DESCRIPTION
### goal
quick fix, don't allow hosts to see `join` button for events they host.
###  test plan
|on event they host | on other events |
| ---| ---|
|![image](https://user-images.githubusercontent.com/99834841/198834398-b46acec7-00f8-48de-9ae5-61b670feefcc.png)| ![image](https://user-images.githubusercontent.com/99834841/198834406-8a9bfa44-f839-4e2d-b156-f2e7bcf58353.png)|
